### PR TITLE
Ignore top-level cv qualifiers when comparing functions

### DIFF
--- a/src/libs/3rdparty/cplusplus/FullySpecifiedType.cpp
+++ b/src/libs/3rdparty/cplusplus/FullySpecifiedType.cpp
@@ -214,6 +214,22 @@ unsigned FullySpecifiedType::flags() const
 void FullySpecifiedType::setFlags(unsigned flags)
 { _flags = flags; }
 
+bool FullySpecifiedType::signatureTypeMatch(const FullySpecifiedType &otherTy, Matcher *matcher) const
+{
+    // When comparing function signatures the top-level cv-qualifiers of the arguments and return type
+    // should be ignored (N3337 - §8.3.5.5).
+    static const unsigned flagsMask = [](){
+        FullySpecifiedType ty;
+        ty.f._isSigned = true;
+        ty.f._isUnsigned = true;
+        return ty._flags;
+    }();
+
+    if ((_flags & flagsMask) != (otherTy._flags & flagsMask))
+        return false;
+    return type()->match(otherTy.type(), matcher);
+}
+
 bool FullySpecifiedType::match(const FullySpecifiedType &otherTy, Matcher *matcher) const
 {
     static const unsigned flagsMask = [](){

--- a/src/libs/3rdparty/cplusplus/FullySpecifiedType.h
+++ b/src/libs/3rdparty/cplusplus/FullySpecifiedType.h
@@ -104,6 +104,7 @@ public:
     bool operator != (const FullySpecifiedType &other) const;
     bool operator < (const FullySpecifiedType &other) const;
 
+    bool signatureTypeMatch(const FullySpecifiedType &otherTy, Matcher *matcher = 0) const;
     bool match(const FullySpecifiedType &otherTy, Matcher *matcher = 0) const;
 
     FullySpecifiedType simplified() const;

--- a/src/libs/3rdparty/cplusplus/Symbols.cpp
+++ b/src/libs/3rdparty/cplusplus/Symbols.cpp
@@ -239,7 +239,7 @@ bool Function::isSignatureEqualTo(const Function *other, Matcher *matcher) const
     for (unsigned i = 0; i < argc; ++i) {
         Symbol *l = argumentAt(i);
         Symbol *r = other->argumentAt(i);
-        if (! l->type().match(r->type(), matcher))
+        if (! l->type().signatureTypeMatch(r->type(), matcher))
             return false;
     }
     return true;

--- a/src/plugins/cppeditor/cppfunctiondecldeflink.cpp
+++ b/src/plugins/cppeditor/cppfunctiondecldeflink.cpp
@@ -484,7 +484,7 @@ static int findUniqueTypeMatch(int sourceParamIndex, Function *sourceFunction, F
         int otherSourceParamIndex = sourceParams.at(i);
         if (sourceParamIndex == otherSourceParamIndex)
             continue;
-        if (sourceParam->type().match(sourceFunction->argumentAt(otherSourceParamIndex)->type()))
+        if (sourceParam->type().signatureTypeMatch(sourceFunction->argumentAt(otherSourceParamIndex)->type()))
             return -1;
     }
 
@@ -493,7 +493,7 @@ static int findUniqueTypeMatch(int sourceParamIndex, Function *sourceFunction, F
     int newParamWithSameTypeIndex = -1;
     for (int i = 0; i < newParams.size(); ++i) {
         int newParamIndex = newParams.at(i);
-        if (sourceParam->type().match(newFunction->argumentAt(newParamIndex)->type())) {
+        if (sourceParam->type().signatureTypeMatch(newFunction->argumentAt(newParamIndex)->type())) {
             if (newParamWithSameTypeIndex != -1)
                 return -1;
             newParamWithSameTypeIndex = newParamIndex;
@@ -810,8 +810,8 @@ ChangeSet FunctionDeclDefLink::changes(const Snapshot &snapshot, int targetOffse
                     renamedTargetParameters[targetParam] = overview.prettyName(replacementName);
 
                 // need to change the type (and name)?
-                if (!newParam->type().match(sourceParam->type())
-                        && !newParam->type().match(targetParam->type())) {
+                if (!newParam->type().signatureTypeMatch(sourceParam->type())
+                        && !newParam->type().signatureTypeMatch(targetParam->type())) {
                     const int parameterTypeStart = targetFile->startOf(targetParamAst);
                     int parameterTypeEnd = 0;
                     if (targetParamAst->declarator)

--- a/src/plugins/cpptools/symbolfinder.cpp
+++ b/src/plugins/cpptools/symbolfinder.cpp
@@ -180,18 +180,7 @@ Function *SymbolFinder::findMatchingDefinition(Symbol *declaration,
                     if (!strict && !best)
                         best = fun;
 
-                    const unsigned argc = declarationTy->argumentCount();
-                    unsigned argIt = 0;
-                    for (; argIt < argc; ++argIt) {
-                        Symbol *arg = fun->argumentAt(argIt);
-                        Symbol *otherArg = declarationTy->argumentAt(argIt);
-                        if (!arg->type().match(otherArg->type()))
-                            break;
-                    }
-
-                    if (argIt == argc
-                            && fun->isConst() == declaration->type().isConst()
-                            && fun->isVolatile() == declaration->type().isVolatile()) {
+                    if (fun->isSignatureEqualTo(declarationTy)) {
                         best = fun;
                     }
                 }


### PR DESCRIPTION
The standard demands that top-level cv qualifiers should be ignored
when comparing function parameters and its return value.

Change-Id: Icaf91872d043b75dd378da1b7e4a7a682bfa3ddd
